### PR TITLE
Google Play now supports screenshots ratio up to 2.3

### DIFF
--- a/main.go
+++ b/main.go
@@ -267,8 +267,8 @@ func checkScreenshots(screenshotsPath string) []error {
 		width := float64(config.width)
 		height := float64(config.height)
 		ratio := math.Max(width, height) / math.Min(height, width)
-		if ratio > 2.0 {
-			const errFmt = "'max:min' edge radio should be at most 2.0: got=%.2f"
+		if ratio > 2.3 {
+			const errFmt = "'max:min' edge radio should be at most 2.3: got=%.2f"
 			errs = append(errs, &validationError{
 				File: imagePath,
 				Err:  fmt.Errorf(errFmt, ratio),


### PR DESCRIPTION
Google Play now supports screenshots ratio up to 2.3
<img width="771" alt="image" src="https://github.com/user-attachments/assets/7e302f0f-5374-4335-8f0d-28b6564142b7">
